### PR TITLE
Pricing mode ta check

### DIFF
--- a/node/src/components/transaction_acceptor.rs
+++ b/node/src/components/transaction_acceptor.rs
@@ -17,8 +17,8 @@ use casper_types::{
     system::auction::ARG_AMOUNT, AddressableEntityHash, AddressableEntityIdentifier, BlockHeader,
     Chainspec, EntityAddr, EntityVersion, EntityVersionKey, ExecutableDeployItem,
     ExecutableDeployItemIdentifier, InitiatorAddr, Key, Package, PackageAddr, PackageHash,
-    PackageIdentifier, Transaction,
-    TransactionEntryPoint, TransactionInvocationTarget, TransactionTarget, U512,
+    PackageIdentifier, Transaction, TransactionEntryPoint, TransactionInvocationTarget,
+    TransactionTarget, U512,
 };
 
 use crate::{
@@ -91,7 +91,7 @@ impl TransactionAcceptor {
             .iter()
             .map(|public_key| public_key.to_account_hash())
             .collect();
-        let balance_hold_interval =  chainspec.core_config.balance_hold_interval.millis();
+        let balance_hold_interval = chainspec.core_config.balance_hold_interval.millis();
         Ok(TransactionAcceptor {
             acceptor_config,
             chainspec,
@@ -662,8 +662,10 @@ impl TransactionAcceptor {
             }
         };
 
-        let entity_version_key =
-            EntityVersionKey::new(self.chainspec.protocol_config.version.value().major, entity_version);
+        let entity_version_key = EntityVersionKey::new(
+            self.chainspec.protocol_config.version.value().major,
+            entity_version,
+        );
 
         if package.is_version_missing(entity_version_key) {
             let error = Error::parameter_failure(

--- a/node/src/components/transaction_acceptor.rs
+++ b/node/src/components/transaction_acceptor.rs
@@ -152,23 +152,6 @@ impl TransactionAcceptor {
             );
         }
 
-        // // If this has been received from the speculative exec server, use the block specified in
-        // // the request, otherwise use the highest complete block.
-        // if let Source::SpeculativeExec = &event_metadata.source {
-        //     let account_key = match event_metadata.transaction.initiator_addr() {
-        //         InitiatorAddr::PublicKey(public_key) => Key::from(public_key.to_account_hash()),
-        //         InitiatorAddr::AccountHash(account_hash) => Key::from(account_hash),
-        //     };
-        //
-        //     return effect_builder
-        //         .get_addressable_entity(*block_header.state_root_hash(), account_key)
-        //         .event(move |result| Event::GetAddressableEntityResult {
-        //             event_metadata,
-        //             maybe_entity: result.into_option(),
-        //             block_header,
-        //         });
-        // }
-
         effect_builder
             .get_highest_complete_block_header_from_storage()
             .event(move |maybe_block_header| Event::GetBlockHeaderResult {

--- a/node/src/components/transaction_acceptor.rs
+++ b/node/src/components/transaction_acceptor.rs
@@ -17,7 +17,7 @@ use casper_types::{
     system::auction::ARG_AMOUNT, AddressableEntityHash, AddressableEntityIdentifier, BlockHeader,
     Chainspec, EntityAddr, EntityVersion, EntityVersionKey, ExecutableDeployItem,
     ExecutableDeployItemIdentifier, InitiatorAddr, Key, Package, PackageAddr, PackageHash,
-    PackageIdentifier, ProtocolVersion, SystemConfig, Transaction, TransactionConfig,
+    PackageIdentifier, Transaction,
     TransactionEntryPoint, TransactionInvocationTarget, TransactionTarget, U512,
 };
 
@@ -72,11 +72,7 @@ impl<REv> ReactorEventT for REv where
 #[derive(Debug, DataSize)]
 pub struct TransactionAcceptor {
     acceptor_config: Config,
-    chain_name: String,
-    protocol_version: ProtocolVersion,
-    cost_table: SystemConfig,
-    transaction_config: TransactionConfig,
-    max_associated_keys: u32,
+    chainspec: Arc<Chainspec>,
     administrators: BTreeSet<AccountHash>,
     #[data_size(skip)]
     metrics: metrics::Metrics,
@@ -86,7 +82,7 @@ pub struct TransactionAcceptor {
 impl TransactionAcceptor {
     pub(crate) fn new(
         acceptor_config: Config,
-        chainspec: &Chainspec,
+        chainspec: Arc<Chainspec>,
         registry: &Registry,
     ) -> Result<Self, prometheus::Error> {
         let administrators = chainspec
@@ -95,16 +91,13 @@ impl TransactionAcceptor {
             .iter()
             .map(|public_key| public_key.to_account_hash())
             .collect();
+        let balance_hold_interval =  chainspec.core_config.balance_hold_interval.millis();
         Ok(TransactionAcceptor {
             acceptor_config,
-            chain_name: chainspec.network_config.name.clone(),
-            protocol_version: chainspec.protocol_version(),
-            cost_table: chainspec.system_costs_config,
-            transaction_config: chainspec.transaction_config,
-            max_associated_keys: chainspec.core_config.max_associated_keys,
+            chainspec,
             administrators,
             metrics: metrics::Metrics::new(registry)?,
-            balance_hold_interval: chainspec.core_config.balance_hold_interval.millis(),
+            balance_hold_interval,
         })
     }
 
@@ -122,20 +115,17 @@ impl TransactionAcceptor {
         let is_config_compliant = match &event_metadata.transaction {
             Transaction::Deploy(deploy) => deploy
                 .is_config_compliant(
-                    &self.chain_name,
-                    &self.cost_table,
-                    &self.transaction_config,
-                    self.max_associated_keys,
+                    &self.chainspec.network_config.name,
+                    &self.chainspec.system_costs_config,
+                    &self.chainspec.transaction_config,
+                    self.chainspec.core_config.max_associated_keys,
                     self.acceptor_config.timestamp_leeway,
                     event_metadata.verification_start_timestamp,
                 )
                 .map_err(|err| Error::InvalidTransaction(err.into())),
             Transaction::V1(txn) => txn
                 .is_config_compliant(
-                    &self.chain_name,
-                    &self.cost_table,
-                    &self.transaction_config,
-                    self.max_associated_keys,
+                    &self.chainspec,
                     self.acceptor_config.timestamp_leeway,
                     event_metadata.verification_start_timestamp,
                 )
@@ -673,7 +663,7 @@ impl TransactionAcceptor {
         };
 
         let entity_version_key =
-            EntityVersionKey::new(self.protocol_version.value().major, entity_version);
+            EntityVersionKey::new(self.chainspec.protocol_config.version.value().major, entity_version);
 
         if package.is_version_missing(entity_version_key) {
             let error = Error::parameter_failure(

--- a/node/src/components/transaction_acceptor/tests.rs
+++ b/node/src/components/transaction_acceptor/tests.rs
@@ -32,9 +32,9 @@ use casper_types::{
     global_state::TrieMerkleProof,
     testing::TestRng,
     Block, BlockV2, CLValue, Chainspec, ChainspecRawBytes, Contract, Deploy, EraId, HashAddr,
-    InvalidDeploy, InvalidTransaction, InvalidTransactionV1, Package, PublicKey, SecretKey,
-    StoredValue, TestBlockBuilder, TimeDiff, Timestamp, Transaction, TransactionSessionKind,
-    TransactionV1, TransactionV1Builder, URef, U512, ProtocolVersion,
+    InvalidDeploy, InvalidTransaction, InvalidTransactionV1, Package, ProtocolVersion, PublicKey,
+    SecretKey, StoredValue, TestBlockBuilder, TimeDiff, Timestamp, Transaction,
+    TransactionSessionKind, TransactionV1, TransactionV1Builder, URef, U512,
 };
 
 use super::*;

--- a/node/src/components/transaction_acceptor/tests.rs
+++ b/node/src/components/transaction_acceptor/tests.rs
@@ -34,7 +34,7 @@ use casper_types::{
     Block, BlockV2, CLValue, Chainspec, ChainspecRawBytes, Contract, Deploy, EraId, HashAddr,
     InvalidDeploy, InvalidTransaction, InvalidTransactionV1, Package, PublicKey, SecretKey,
     StoredValue, TestBlockBuilder, TimeDiff, Timestamp, Transaction, TransactionSessionKind,
-    TransactionV1, TransactionV1Builder, URef, U512,
+    TransactionV1, TransactionV1Builder, URef, U512, ProtocolVersion,
 };
 
 use super::*;
@@ -883,7 +883,7 @@ impl reactor::Reactor for Reactor {
         let storage_withdir = WithDir::new(storage_tempdir.path(), storage_config);
 
         let transaction_acceptor =
-            TransactionAcceptor::new(Config::default(), chainspec.as_ref(), registry).unwrap();
+            TransactionAcceptor::new(Config::default(), Arc::clone(&chainspec), registry).unwrap();
 
         let storage = Storage::new(
             &storage_withdir,

--- a/node/src/reactor/main_reactor.rs
+++ b/node/src/reactor/main_reactor.rs
@@ -1206,7 +1206,7 @@ impl reactor::Reactor for MainReactor {
         let upgrade_watcher =
             UpgradeWatcher::new(chainspec.as_ref(), config.upgrade_watcher, &root_dir)?;
         let transaction_acceptor =
-            TransactionAcceptor::new(config.transaction_acceptor, chainspec.as_ref(), registry)?;
+            TransactionAcceptor::new(config.transaction_acceptor, Arc::clone(&chainspec), registry)?;
         let transaction_buffer =
             TransactionBuffer::new(Arc::clone(&chainspec), config.transaction_buffer, registry)?;
 

--- a/node/src/reactor/main_reactor.rs
+++ b/node/src/reactor/main_reactor.rs
@@ -1205,8 +1205,11 @@ impl reactor::Reactor for MainReactor {
         );
         let upgrade_watcher =
             UpgradeWatcher::new(chainspec.as_ref(), config.upgrade_watcher, &root_dir)?;
-        let transaction_acceptor =
-            TransactionAcceptor::new(config.transaction_acceptor, Arc::clone(&chainspec), registry)?;
+        let transaction_acceptor = TransactionAcceptor::new(
+            config.transaction_acceptor,
+            Arc::clone(&chainspec),
+            registry,
+        )?;
         let transaction_buffer =
             TransactionBuffer::new(Arc::clone(&chainspec), config.transaction_buffer, registry)?;
 

--- a/types/src/chainspec/pricing_handling.rs
+++ b/types/src/chainspec/pricing_handling.rs
@@ -1,8 +1,8 @@
-use core::fmt::{Display, Formatter};
 use crate::{
     bytesrepr,
     bytesrepr::{FromBytes, ToBytes},
 };
+use core::fmt::{Display, Formatter};
 #[cfg(feature = "datasize")]
 use datasize::DataSize;
 use serde::{Deserialize, Serialize};

--- a/types/src/chainspec/pricing_handling.rs
+++ b/types/src/chainspec/pricing_handling.rs
@@ -1,3 +1,4 @@
+use core::fmt::{Display, Formatter};
 use crate::{
     bytesrepr,
     bytesrepr::{FromBytes, ToBytes},
@@ -22,6 +23,19 @@ pub enum PricingHandling {
     Classic,
     /// The costs are fixed, per the cost tables.
     Fixed,
+}
+
+impl Display for PricingHandling {
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
+        match self {
+            PricingHandling::Classic => {
+                write!(f, "PricingHandling::Classic")
+            }
+            PricingHandling::Fixed => {
+                write!(f, "PricingHandling::Fixed")
+            }
+        }
+    }
 }
 
 impl ToBytes for PricingHandling {

--- a/types/src/lib.rs
+++ b/types/src/lib.rs
@@ -22,7 +22,6 @@
 extern crate alloc;
 
 extern crate core;
-
 mod access_rights;
 pub mod account;
 pub mod addressable_entity;

--- a/types/src/transaction/transaction_v1.rs
+++ b/types/src/transaction/transaction_v1.rs
@@ -32,11 +32,11 @@ use super::{
 #[cfg(any(feature = "std", test))]
 use super::{GasLimited, InitiatorAddrAndSecretKey};
 #[cfg(any(all(feature = "std", feature = "testing"), test))]
-use crate::testing::TestRng;
+use crate::{testing::TestRng, Chainspec,
+            chainspec::PricingHandling};
 use crate::{
     bytesrepr::{self, FromBytes, ToBytes},
-    chainspec::PricingHandling,
-    crypto, Chainspec, Digest, DisplayIter, RuntimeArgs, SecretKey, TimeDiff, Timestamp,
+    crypto, Digest, DisplayIter, RuntimeArgs, SecretKey, TimeDiff, Timestamp,
     TransactionRuntime, TransactionSessionKind,
 };
 #[cfg(any(feature = "std", test))]

--- a/types/src/transaction/transaction_v1.rs
+++ b/types/src/transaction/transaction_v1.rs
@@ -382,7 +382,6 @@ impl TransactionV1 {
                 if let PricingHandling::Classic = price_handling {
                 } else {
                     return Err(InvalidTransactionV1::InvalidPricingMode {
-                        price_handling,
                         price_mode: price_mode.clone(),
                     });
                 }
@@ -391,7 +390,6 @@ impl TransactionV1 {
                 if let PricingHandling::Fixed = price_handling {
                 } else {
                     return Err(InvalidTransactionV1::InvalidPricingMode {
-                        price_handling,
                         price_mode: price_mode.clone(),
                     });
                 }
@@ -400,7 +398,6 @@ impl TransactionV1 {
                 // Currently Reserved isn't implemented and we should
                 // not be accepting transactions with this mode.
                 return Err(InvalidTransactionV1::InvalidPricingMode {
-                    price_handling,
                     price_mode: price_mode.clone(),
                 });
             }
@@ -1133,7 +1130,6 @@ mod tests {
 
         let current_timestamp = reserved_transaction.timestamp();
         let expected_error = InvalidTransactionV1::InvalidPricingMode {
-            price_handling: expected_pricing_handling,
             price_mode: reserved_mode,
         };
         assert_eq!(
@@ -1173,7 +1169,6 @@ mod tests {
 
         let current_timestamp = fixed_mode_transaction.timestamp();
         let expected_error = InvalidTransactionV1::InvalidPricingMode {
-            price_handling: PricingHandling::Classic,
             price_mode: fixed_mode_transaction.pricing_mode().clone(),
         };
 
@@ -1210,7 +1205,6 @@ mod tests {
 
         let current_timestamp = classic_mode_transaction.timestamp();
         let expected_error = InvalidTransactionV1::InvalidPricingMode {
-            price_handling: PricingHandling::Fixed,
             price_mode: classic_mode_transaction.pricing_mode().clone(),
         };
 

--- a/types/src/transaction/transaction_v1/errors_v1.rs
+++ b/types/src/transaction/transaction_v1/errors_v1.rs
@@ -13,8 +13,10 @@ use serde::Serialize;
 use super::super::TransactionEntryPoint;
 #[cfg(doc)]
 use super::TransactionV1;
-use crate::{bytesrepr, crypto, CLType, DisplayIter, TimeDiff, Timestamp, U512, PricingMode};
-use crate::chainspec::PricingHandling;
+use crate::{
+    bytesrepr, chainspec::PricingHandling, crypto, CLType, DisplayIter, PricingMode, TimeDiff,
+    Timestamp, U512,
+};
 
 /// Returned when a [`TransactionV1`] fails validation.
 #[derive(Clone, Eq, PartialEq, Debug)]
@@ -152,7 +154,7 @@ pub enum InvalidTransaction {
         price_handling: PricingHandling,
         /// The pricing mode as specified by the transaction.
         price_mode: PricingMode,
-    }
+    },
 }
 
 impl Display for InvalidTransaction {
@@ -273,7 +275,10 @@ impl Display for InvalidTransaction {
             InvalidTransaction::UnableToCalculateGasLimit => {
                 write!(formatter, "unable to calculate gas limit",)
             }
-            InvalidTransaction::InvalidPricingMode { price_handling, price_mode} => {
+            InvalidTransaction::InvalidPricingMode {
+                price_handling,
+                price_mode,
+            } => {
                 write!(formatter, "received a transaction with mode {price_mode} with price handling {price_handling}")
             }
         }
@@ -310,7 +315,7 @@ impl StdError for InvalidTransaction {
             | InvalidTransaction::EmptyModuleBytes
             | InvalidTransaction::GasPriceConversion { .. }
             | InvalidTransaction::UnableToCalculateGasLimit
-            | InvalidTransaction::InvalidPricingMode { .. }=> None,
+            | InvalidTransaction::InvalidPricingMode { .. } => None,
         }
     }
 }

--- a/types/src/transaction/transaction_v1/errors_v1.rs
+++ b/types/src/transaction/transaction_v1/errors_v1.rs
@@ -13,9 +13,11 @@ use serde::Serialize;
 use super::super::TransactionEntryPoint;
 #[cfg(doc)]
 use super::TransactionV1;
+#[cfg(feature = "std")]
+use crate::{chainspec::PricingHandling};
 use crate::{
-    bytesrepr, chainspec::PricingHandling, crypto, CLType, DisplayIter, PricingMode, TimeDiff,
-    Timestamp, U512,
+    bytesrepr, crypto, CLType, DisplayIter, TimeDiff,
+    Timestamp, U512, PricingMode,
 };
 
 /// Returned when a [`TransactionV1`] fails validation.

--- a/types/src/transaction/transaction_v1/errors_v1.rs
+++ b/types/src/transaction/transaction_v1/errors_v1.rs
@@ -13,8 +13,6 @@ use serde::Serialize;
 use super::super::TransactionEntryPoint;
 #[cfg(doc)]
 use super::TransactionV1;
-#[cfg(feature = "std")]
-use crate::{chainspec::PricingHandling};
 use crate::{
     bytesrepr, crypto, CLType, DisplayIter, TimeDiff,
     Timestamp, U512, PricingMode,
@@ -152,8 +150,6 @@ pub enum InvalidTransaction {
     UnableToCalculateGasLimit,
     /// Invalid combination of pricing handling and pricing mode.
     InvalidPricingMode {
-        /// The price handling as determined by the chainspec.
-        price_handling: PricingHandling,
         /// The pricing mode as specified by the transaction.
         price_mode: PricingMode,
     },
@@ -278,10 +274,9 @@ impl Display for InvalidTransaction {
                 write!(formatter, "unable to calculate gas limit",)
             }
             InvalidTransaction::InvalidPricingMode {
-                price_handling,
                 price_mode,
             } => {
-                write!(formatter, "received a transaction with mode {price_mode} with price handling {price_handling}")
+                write!(formatter, "received a transaction with an invalid mode {price_mode}")
             }
         }
     }


### PR DESCRIPTION
CHANGELOG:

- Tweaked TransactionAcceptor to hold onto a chainspec
- Added a checking to TransactionV1 config compliance ensuring the pricing mode in the header matches the price handling in the chainspec
- Added unit level and component level tests to ensure the invalid combination of modes and handling raises the invalid transaction error