### PR TITLE
Spicy fixes 2

### DIFF
--- a/node/src/components/contract_runtime/types.rs
+++ b/node/src/components/contract_runtime/types.rs
@@ -160,6 +160,10 @@ impl ExecutionArtifactBuilder {
         }
         if let (None, BalanceHoldResult::Failure(err)) = (&self.error_message, hold_result) {
             self.error_message = Some(format!("{}", err));
+            // NOTE: if holding balance fails, we revert any prior effects.
+            // and only commit effects produced by balance hold (if any).
+            self.effects = hold_result.effects();
+            return Ok(self);
         }
         self.with_appended_effects(hold_result.effects());
         Ok(self)

--- a/node/src/components/storage.rs
+++ b/node/src/components/storage.rs
@@ -126,7 +126,7 @@ pub struct Storage {
     /// Storage location.
     root: PathBuf,
     /// Block store
-    pub(crate) block_store: IndexedLmdbBlockStore<'static>,
+    pub(crate) block_store: IndexedLmdbBlockStore,
     /// Runs of completed blocks known in storage.
     completed_blocks: DisjointSequences,
     /// The activation point era of the current protocol version.

--- a/resources/local/chainspec.toml.in
+++ b/resources/local/chainspec.toml.in
@@ -290,8 +290,8 @@ max_topics_per_contract = 128
 max_message_size = 1_024
 
 [system_costs]
-install_upgrade_gas_limit = 0
-standard_transaction_gas_limit = 0
+install_upgrade_gas_limit = 3_500_000_000
+standard_transaction_gas_limit = 350_000_000
 
 [system_costs.auction_costs]
 get_era_validators = 10_000

--- a/resources/test/sse_data_schema.json
+++ b/resources/test/sse_data_schema.json
@@ -1700,7 +1700,8 @@
               "type": "object",
               "required": [
                 "paid_amount",
-                "receipt"
+                "receipt",
+                "strike_price"
               ],
               "properties": {
                 "receipt": {
@@ -1718,6 +1719,12 @@
                       "$ref": "#/definitions/U512"
                     }
                   ]
+                },
+                "strike_price": {
+                  "description": "The gas price at the time of reservation.",
+                  "type": "integer",
+                  "format": "uint8",
+                  "minimum": 0.0
                 }
               },
               "additionalProperties": false
@@ -2187,7 +2194,7 @@
                   "description": "A record of version 1 Transfers performed while executing the deploy.",
                   "type": "array",
                   "items": {
-                    "$ref": "#/definitions/TransferV1Addr"
+                    "$ref": "#/definitions/TransferAddr"
                   }
                 },
                 "cost": {
@@ -2235,7 +2242,7 @@
                   "description": "A record of Transfers performed while executing the deploy.",
                   "type": "array",
                   "items": {
-                    "$ref": "#/definitions/TransferV1Addr"
+                    "$ref": "#/definitions/TransferAddr"
                   }
                 },
                 "cost": {
@@ -2661,7 +2668,7 @@
           "description": "Version 1 transfers performed by the Deploy.",
           "type": "array",
           "items": {
-            "$ref": "#/definitions/TransferV1Addr"
+            "$ref": "#/definitions/TransferAddr"
           }
         },
         "from": {
@@ -2691,7 +2698,7 @@
       },
       "additionalProperties": false
     },
-    "TransferV1Addr": {
+    "TransferAddr": {
       "description": "Hex-encoded version 1 transfer address.",
       "type": "string"
     },

--- a/storage/src/block_store/lmdb/versioned_databases.rs
+++ b/storage/src/block_store/lmdb/versioned_databases.rs
@@ -89,7 +89,7 @@ impl VersionedValue for BlockSignatures {
     type Legacy = BlockSignaturesV1;
 }
 
-impl<'a> VersionedValue for Transfers<'a> {
+impl VersionedValue for Transfers {
     type Legacy = Vec<TransferV1>;
 }
 

--- a/storage/src/block_store/types/transfers.rs
+++ b/storage/src/block_store/types/transfers.rs
@@ -1,5 +1,3 @@
-use std::borrow::Cow;
-
 use serde::{Deserialize, Serialize};
 
 use casper_types::{
@@ -12,35 +10,27 @@ use casper_types::{
 /// It exists to allow the `impl From<Vec<TransferV1>>` to be written, making the type suitable for
 /// use as a parameter in a `VersionedDatabases`.
 #[derive(Clone, Serialize, Deserialize, Debug, Default, PartialEq, Eq)]
-pub(in crate::block_store) struct Transfers<'a>(Cow<'a, Vec<Transfer>>);
+pub(in crate::block_store) struct Transfers(Vec<Transfer>);
 
-impl<'a> Transfers<'a> {
+impl Transfers {
     pub(in crate::block_store) fn into_owned(self) -> Vec<Transfer> {
-        self.0.into_owned()
+        self.0
     }
 }
 
-impl<'a> From<Vec<TransferV1>> for Transfers<'a> {
+impl From<Vec<TransferV1>> for Transfers {
     fn from(v1_transfers: Vec<TransferV1>) -> Self {
-        Transfers(Cow::Owned(
-            v1_transfers.into_iter().map(Transfer::V1).collect(),
-        ))
+        Transfers(v1_transfers.into_iter().map(Transfer::V1).collect())
     }
 }
 
-impl<'a> From<Vec<Transfer>> for Transfers<'a> {
+impl From<Vec<Transfer>> for Transfers {
     fn from(transfers: Vec<Transfer>) -> Self {
-        Transfers(Cow::Owned(transfers))
+        Transfers(transfers)
     }
 }
 
-impl<'a> From<&'a Vec<Transfer>> for Transfers<'a> {
-    fn from(transfers: &'a Vec<Transfer>) -> Self {
-        Transfers(Cow::Borrowed(transfers))
-    }
-}
-
-impl<'a> ToBytes for Transfers<'a> {
+impl ToBytes for Transfers {
     fn to_bytes(&self) -> Result<Vec<u8>, bytesrepr::Error> {
         self.0.to_bytes()
     }
@@ -54,9 +44,9 @@ impl<'a> ToBytes for Transfers<'a> {
     }
 }
 
-impl<'a> FromBytes for Transfers<'a> {
+impl FromBytes for Transfers {
     fn from_bytes(bytes: &[u8]) -> Result<(Self, &[u8]), bytesrepr::Error> {
         Vec::<Transfer>::from_bytes(bytes)
-            .map(|(transfers, remainder)| (Transfers(Cow::Owned(transfers)), remainder))
+            .map(|(transfers, remainder)| (Transfers(transfers), remainder))
     }
 }

--- a/storage/src/global_state/state/mod.rs
+++ b/storage/src/global_state/state/mod.rs
@@ -794,8 +794,8 @@ pub trait StateProvider {
         BalanceHoldResult::success(
             total_balance,
             available_balance,
-            held_amount,
             request.hold_amount(),
+            held_amount,
             effects,
         )
     }

--- a/types/src/chainspec/vm_config/system_config.rs
+++ b/types/src/chainspec/vm_config/system_config.rs
@@ -13,10 +13,10 @@ use crate::{
 };
 
 /// Default gas limit of install / upgrade contracts
-pub const DEFAULT_INSTALL_UPGRADE_GAS_LIMIT: u32 = 0; // 100_000_000; TODO: reinstate when adding new payment logic
+pub const DEFAULT_INSTALL_UPGRADE_GAS_LIMIT: u32 = 3_500_000_000;
 
 /// Default gas limit of standard transactions
-pub const DEFAULT_STANDARD_TRANSACTION_GAS_LIMIT: u32 = 0; // 100_000_000; TODO: reinstate when adding new payment logic
+pub const DEFAULT_STANDARD_TRANSACTION_GAS_LIMIT: u32 = 350_000_000;
 
 /// Definition of costs in the system.
 ///

--- a/types/src/transaction/transaction_v1.rs
+++ b/types/src/transaction/transaction_v1.rs
@@ -647,13 +647,16 @@ impl GasLimited for TransactionV1 {
                     },
                 )?
             }
-            PricingMode::Reserved { paid_amount, .. } => {
-                let actual_price = 1;
+            PricingMode::Reserved {
+                paid_amount,
+                strike_price,
+                ..
+            } => {
                 // prepaid, if receipt is legit (future use, not currently implemented)
-                Gas::from_motes(Motes::new(*paid_amount), actual_price).ok_or(
+                Gas::from_motes(Motes::new(*paid_amount), *strike_price).ok_or(
                     InvalidTransactionV1::GasPriceConversion {
                         amount: paid_amount.as_u64(),
-                        gas_price: actual_price,
+                        gas_price: *strike_price,
                     },
                 )?
             }


### PR DESCRIPTION
Revert effects if hold failed.
Set non-zero gas limits for install/upgrade and standard txn.
Fix call to `BalanceHoldResult::success`.
Add `strike_price` for Reserved pricing mode to track the price at the moment of the reservation.
casper-storage: remove lifetime for transfers
