### PR TITLE
scratch state: use a BTreeMap for tracking keys in the cache

### DIFF
--- a/storage/src/global_state/state/lmdb.rs
+++ b/storage/src/global_state/state/lmdb.rs
@@ -1,5 +1,5 @@
 use itertools::Itertools;
-use std::{collections::HashMap, ops::Deref, sync::Arc};
+use std::{collections::BTreeMap, ops::Deref, sync::Arc};
 
 use lmdb::{DatabaseFlags, RwTransaction};
 
@@ -118,7 +118,7 @@ impl LmdbGlobalState {
     pub fn put_stored_values(
         &self,
         prestate_hash: Digest,
-        stored_values: HashMap<Key, StoredValue>,
+        stored_values: BTreeMap<Key, StoredValue>,
     ) -> Result<Digest, GlobalStateError> {
         let scratch_trie = self.get_scratch_store();
         let new_state_root = put_stored_values::<_, _, GlobalStateError>(

--- a/storage/src/global_state/state/mod.rs
+++ b/storage/src/global_state/state/mod.rs
@@ -9,7 +9,7 @@ pub mod scratch;
 use num_rational::Ratio;
 use std::{
     cell::RefCell,
-    collections::{BTreeMap, BTreeSet, HashMap},
+    collections::{BTreeMap, BTreeSet},
     convert::TryFrom,
     rc::Rc,
 };
@@ -1820,7 +1820,7 @@ pub fn put_stored_values<'a, R, S, E>(
     environment: &'a R,
     store: &S,
     prestate_hash: Digest,
-    stored_values: HashMap<Key, StoredValue>,
+    stored_values: BTreeMap<Key, StoredValue>,
 ) -> Result<Digest, E>
 where
     R: TransactionSource<'a, Handle = S::Handle>,


### PR DESCRIPTION
We need to preserve a consistent order when caching keys in the scratch state.